### PR TITLE
[x] Red flag implemented in api

### DIFF
--- a/country/management/commands/import_red_flag.py
+++ b/country/management/commands/import_red_flag.py
@@ -4,7 +4,7 @@ from django.conf import settings
 import gspread
 from country.models import Country, Tender, EquityCategory, EquityKeywords, GoodsServices, RedFlag
 from django.db.models import Q
-from country.tasks import import_tender_data,fetch_equity_data,convert_local_to_usd,process_currency_conversion,process_redflag, clear_redflag
+from country.tasks import import_tender_data,fetch_equity_data,convert_local_to_usd,process_currency_conversion,process_redflag, clear_redflag, process_redflag7,process_redflag6
 
 
 class Command(BaseCommand):
@@ -14,32 +14,17 @@ class Command(BaseCommand):
         tenders = Tender.objects.all()
         for tender in tenders:
             id = tender.id
-            r = clear_redflag.apply_async(args=(id,), queue='covid19')
+            a = clear_redflag.apply_async(args=(id,), queue='covid19')
             
         print('All cleared !!')
         print('Processing Red Flag in tender !!')
         
-        tender_instance = Tender.objects.filter(supplier__isnull=False,buyer__isnull=False).values('buyer__buyer_name','supplier__supplier_name')
-        flag7_obj = RedFlag.objects.get(function_name='flag7')
-        flag6_obj = RedFlag.objects.get(function_name='flag6')
-
-        for instance in tender_instance:
-            concentration = Tender.objects.filter(buyer__buyer_name=instance['buyer__buyer_name'],supplier__supplier_name=instance['supplier__supplier_name'])
-            if len(concentration) > 10:    # supplier who has signed X(10) percent or more of their contracts with the same buyer (wins tenders from the same buyer);
-                for i in concentration:
-                    obj = Tender.objects.get(id=i.id)
-                    obj.red_flag.add(flag7_obj)
-        
-
+        tender_instance = Tender.objects.filter(supplier__isnull=False,buyer__isnull=False).values('id','buyer__buyer_name','supplier__supplier_name','supplier__supplier_address')
         for tender in tender_instance:
-            a = Tender.objects.values('buyer__buyer_name').filter(supplier__supplier_name=tender['supplier__supplier_name'],supplier__supplier_address=tender['supplier__supplier_address']).distinct('buyer__buyer_name')
-            if len(a) > 2:
-                if a[0]['buyer__buyer_name']==a[1]['buyer__buyer_name']:
-                    for obj in a:
-                        objs = Tender.objects.get(id=obj.id)
-                        objs.red_flag.add(flag6_obj)
-
-
+            id = tender['id']
+            b = process_redflag7.apply_async(args=(id,tender), queue='covid19')
+            c = process_redflag6.apply_async(args=(id,tender), queue='covid19')
+        
         for tender in tenders:
             id = tender.id
             r = process_redflag.apply_async(args=(id,), queue='covid19')

--- a/country/models.py
+++ b/country/models.py
@@ -75,16 +75,16 @@ class CurrencyConversionCache(models.Model):
 
 class SupplierManager(models.Manager):
     def get_queryset(self):
-        return super().get_queryset().annotate(amount_local=Sum('tenders__goods_services__contract_value_local'),amount_usd=Sum('tenders__goods_services__contract_value_usd'),country_name=F('tenders__country__name'),product_category_count=Count('tenders__goods_services__goods_services_category', distinct=True),tender_count=Count('tenders__id',distinct=True),buyer_count=Count('tenders__buyer_id',filter=Q(tenders__buyer_id__isnull=False),distinct=True))
+        return super().get_queryset().annotate(amount_local=Sum('tenders__goods_services__contract_value_local'),amount_usd=Sum('tenders__goods_services__contract_value_usd'),country_name=F('tenders__country__name'),red_flag_count=Count('tenders__red_flag',distinct=True),product_category_count=Count('tenders__goods_services__goods_services_category', distinct=True),tender_count=Count('tenders__id',distinct=True),buyer_count=Count('tenders__buyer_id',filter=Q(tenders__buyer_id__isnull=False),distinct=True))
 
 
 class BuyerManager(models.Manager):
     def get_queryset(self):
-        return super().get_queryset().annotate(amount_local=Sum('tenders__goods_services__contract_value_local'),amount_usd=Sum('tenders__goods_services__contract_value_usd'),country_name=F('tenders__country__name'),product_category_count=Count('tenders__goods_services__goods_services_category', distinct=True),tender_count=Count('tenders__id',distinct=True),supplier_count=Count('tenders__supplier_id',filter=Q(tenders__supplier_id__isnull=False),distinct=True))
+        return super().get_queryset().annotate(amount_local=Sum('tenders__goods_services__contract_value_local'),amount_usd=Sum('tenders__goods_services__contract_value_usd'),country_name=F('tenders__country__name'),red_flag_count=Count('tenders__red_flag',distinct=True),product_category_count=Count('tenders__goods_services__goods_services_category', distinct=True),tender_count=Count('tenders__id',distinct=True),supplier_count=Count('tenders__supplier_id',filter=Q(tenders__supplier_id__isnull=False),distinct=True))
 
 class TenderManager(models.Manager):
     def get_queryset(self):
-        return super().get_queryset().annotate(amount_local=Sum('goods_services__contract_value_local'),amount_usd=Sum('goods_services__contract_value_usd'))
+        return super().get_queryset().annotate(amount_local=Sum('goods_services__contract_value_local'),amount_usd=Sum('goods_services__contract_value_usd'),red_flag_count=Count('red_flag'),tender_count=Count('id',distinct=True))
 
 class Supplier(models.Model):
     supplier_id = models.CharField(verbose_name=_('Supplier ID'), max_length=50, null=False, unique=True)

--- a/country/tasks.py
+++ b/country/tasks.py
@@ -558,3 +558,22 @@ def clear_redflag(id):
     tender = Tender.objects.get(id=id)
     tender.red_flag.clear()
     print(f'end of {id}')
+
+@app.task(name='process_red_flag7')
+def process_redflag7(id,tender):
+    flag7_obj = RedFlag.objects.get(function_name='flag7')
+    concentration = Tender.objects.filter(buyer__buyer_name=tender['buyer__buyer_name'],supplier__supplier_name=tender['supplier__supplier_name'])
+    if len(concentration) > 10:    # supplier who has signed X(10) percent or more of their contracts with the same buyer (wins tenders from the same buyer);
+        for i in concentration:
+            obj = Tender.objects.get(id=i.id)
+            obj.red_flag.add(flag7_obj)
+
+@app.task(name='process_red_flag6')
+def process_redflag6(id,tender):
+    flag6_obj = RedFlag.objects.get(function_name='flag6')
+    a = Tender.objects.values('buyer__buyer_name').filter(supplier__supplier_name=tender['supplier__supplier_name'],supplier__supplier_address=tender['supplier__supplier_address']).distinct('buyer__buyer_name')
+    if len(a) > 2:
+        if a[0]['buyer__buyer_name']==a[1]['buyer__buyer_name']:
+            for obj in a:
+                objs = Tender.objects.get(id=obj.id)
+                objs.red_flag.add(flag6_obj)

--- a/country/views.py
+++ b/country/views.py
@@ -19,6 +19,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.http.response import HttpResponseRedirect
 import os
+from django.core.exceptions import MultipleObjectsReturned
 
 class TenderPagination(PageNumberPagination):
     page_size = 50
@@ -109,6 +110,13 @@ class BuyerView(viewsets.ModelViewSet):
     ordering_fields = ['tender_count','supplier_count','product_category_count','buyer_name','country_name','amount_usd','amount_local']
     ordering = ['-id']
 
+    def retrieve(self, request, *args, **kwargs):
+        # do your customization here
+        pk = self.kwargs['pk'] 
+        instance = Buyer.objects.filter(id=pk)[0]
+        serializer = self.get_serializer(instance)
+        return Response(serializer.data)
+    
     def get_queryset(self):
     #    country, buyer name, value range, red flag range
         country =  self.request.GET.get('country',None)
@@ -137,6 +145,13 @@ class SupplierView(viewsets.ModelViewSet):
     serializer_class = SupplierSerializer
     ordering_fields = ['tender_count','buyer_count','product_category_count','supplier_name','country_name','amount_usd','amount_local']
     ordering = ['-id']
+
+    def retrieve(self, request, *args, **kwargs):
+        # do your customization here
+        pk = self.kwargs['pk'] 
+        instance = Supplier.objects.filter(id=pk)[0]
+        serializer = self.get_serializer(instance)
+        return Response(serializer.data)
 
     def get_queryset(self):
     #    country, buyer name, value range, red flag range

--- a/vizualization/views.py
+++ b/vizualization/views.py
@@ -1635,7 +1635,6 @@ class ContractRedFlagsView(APIView):
         product =  self.request.GET.get('product',None)
         if country: filter_args['country__country_code_alpha_2'] = country
         if supplier: filter_args = add_filter_args('supplier',supplier,filter_args)
-        if supplier: filter_args = add_filter_args('supplier',supplier,filter_args)
         if buyer: filter_args = add_filter_args('buyer',buyer,filter_args)
         if product: filter_args['goods_services__goods_services_category__id'] = product
         red_flags = RedFlag.objects.all()


### PR DESCRIPTION
[x] Contracts table. Added a key as red_flag_count in api response.
[x] Contract detail. Added list of applied red flags info as
    "red_flags" : [{"red_flag_id": 12, "red_flag": "Direct open ..."}]
[x] Buyer profile. In /visualization/contract-red-flags/ api added buyer id filter.
[x] Supplier profile. In /visualization/contract-red-flags/ api added supplier id filter.
[x] Buyers table. Added a key as red_flag_tender_count, red_flag_tender_percentage in api response.
[x] Suppliers table. Added a key as red_flag_tender_count, red_flag_tender_percentage in api response.
[x] Supplier_name and buyer_name added in tender serializer
[x] distinct count for red_flag